### PR TITLE
Seon taewoong patch 1 interpolate nan values fun

### DIFF
--- a/hrvanalysis/preprocessing.py
+++ b/hrvanalysis/preprocessing.py
@@ -263,7 +263,7 @@ def interpolate_nan_values(rr_intervals: list,
                            limit_area: str = None,
                            limit_direction: str = "forward",
                            limit=None,) -> list:
-    """
+       """
     Function that interpolate Nan values with linear interpolation
 
     Parameters
@@ -283,16 +283,22 @@ def interpolate_nan_values(rr_intervals: list,
     interpolated_rr_intervals : list
         new list with outliers replaced by interpolated values.
     """
-    # search first nan data and fill it post value until it is not nan
-    if np.isnan(rr_intervals[0]):
-        start_idx = 0
-
-        while np.isnan(rr_intervals[start_idx]):
-            start_idx += 1
-
-        rr_intervals[0:start_idx] = [rr_intervals[start_idx]] * start_idx
-    else:
+    # search start & end nan data and fill it post & previous value until it is not nan
+    rr_intervals = np.array(rr_intervals)
+    # handing with first nan
+    idx_first = 0
+    idx_tail = len(rr_intervals) - 1
+    while np.isnan(rr_intervals[idx_first]):
+        idx_first += 1
+    # handing with tail nan
+    while np.isnan(rr_intervals[idx_tail]):
+        idx_tail -= 1
+    # interpolation start & end
+    if (idx_first == 0) & (idx_tail == len(rr_intervals) - 1):
         pass
+    else:
+        rr_intervals[idx_tail::] = rr_intervals[idx_tail]
+        rr_intervals[0:idx_first] = rr_intervals[idx_first]
     # change rr_intervals to pd series
     series_rr_intervals_cleaned = pd.Series(rr_intervals)
     # Interpolate nan values and convert pandas object to list of values

--- a/hrvanalysis/preprocessing.py
+++ b/hrvanalysis/preprocessing.py
@@ -258,12 +258,13 @@ def _remove_outlier_acar(rr_intervals: List[float], custom_rule=0.2) -> Tuple[li
     return nn_intervals, outlier_count
 
 
+
 def interpolate_nan_values(rr_intervals: list,
                            interpolation_method: str = "linear",
                            limit_area: str = None,
                            limit_direction: str = "forward",
                            limit=None,) -> list:
-       """
+    """
     Function that interpolate Nan values with linear interpolation
 
     Parameters


### PR DESCRIPTION
Current issue: this function can not deal nan value in first data

This changed function search start & end nan data and fill it post & previous value until it is not nan

---
example)

current version:
---
```
import numpy as np
import hrvanalysis

rri = [np.nan, np.nan, 1, 2, 3, 4, np.nan, np.nan, np.nan, 9, 10, 11, np.nan]
print(hrvanalysis.preprocessing.interpolate_nan_values(rri))

out: [nan, nan, 1.0, 2.0, 3.0, 4.0, 5.25, 6.5, 7.75, 9.0, 10.0, 11.0, 11.0]

```

changed version
---

```
import numpy as np
import hrvanalysis

rri = [np.nan, np.nan, 1, 2, 3, 4, np.nan, np.nan, np.nan, 9, 10, 11, np.nan]
print(hrvanalysis.preprocessing.interpolate_nan_values(rri))
[1.0, 1.0, 1.0, 2.0, 3.0, 4.0, 5.25, 6.5, 7.75, 9.0, 10.0, 11.0, 11.0]

```


---