### PR TITLE
added import check from astropy for LombScargle

### DIFF
--- a/hrvanalysis/extract_features.py
+++ b/hrvanalysis/extract_features.py
@@ -9,7 +9,11 @@ import numpy as np
 import nolds
 from scipy import interpolate
 from scipy import signal
-from astropy.stats import LombScargle
+try:
+    from astropy.stats import LombScargle
+except ImportError:
+    # API change from astropy 6.0.0
+    from astropy.timeseries import LombScargle
 
 # limit functions that user might import using "from hrv-analysis import *"
 __all__ = ['get_time_domain_features', 'get_frequency_domain_features',


### PR DESCRIPTION
I've noticed that Astropy 6.0.0 changed part of the API so now LombScargle periodogram fails to import (see https://docs.astropy.org/en/v6.0.0/changelog.html)

I've included an import check to be sure it doesn't crash.
I don't know if astropy 3.0.4 is a hard requirement, but if it's just for LombScargle it can be probably increased to the latest version.