### PR TITLE
fix: working LombScargle with recent astropy versions

### DIFF
--- a/hrvanalysis/extract_features.py
+++ b/hrvanalysis/extract_features.py
@@ -9,7 +9,7 @@ import numpy as np
 import nolds
 from scipy import interpolate
 from scipy import signal
-from astropy.stats import LombScargle
+from astropy.timeseries import LombScargle
 
 # limit functions that user might import using "from hrv-analysis import *"
 __all__ = ['get_time_domain_features', 'get_frequency_domain_features',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ numpy>=1.15.1
 scipy>=1.1.0
 pandas>=0.23.4
 matplotlib>=2.2.2
-astropy>=3.0.4
+astropy>=3.2.2
 nolds>=0.4.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     python_requires='>=3.5',
     install_requires=[
         "numpy>=1.15.1",
-        "astropy>=3.0.4",
+        "astropy>=3.2.2",
         "nolds>=0.4.1",
         "scipy>=1.1.0",
         "pandas>=0.23.4",


### PR DESCRIPTION
Hello,

Following issue in: https://github.com/Aura-healthcare/hrv-analysis/pull/40. Thank you a lot for the research done there!

From my point of view, the best way to fix is:
- Bump requirements of astropy to 3.2.2 (from 3.0.4)
- Import LombScargle from astropy.timeseries in hrvanalysis/extract_features.py module

Why/
- On release 3.2.2 (5 years ago...), LombScargle was moved to timeseries module, but could be used both from astropy.stats and from astropy.timeseries for compatiblity. See [https://github.com/astropy/astropy/pull/8591](https://github.com/astropy/astropy/pull/8591)
- On pull request https://github.com/astropy/astropy/pull/15530 , the compatibilty was removed.
- From actual requirements (3.0.4) to targeted requirements (3.2.2), no significant change was made to LombScargle, only improvement and unit testing. So it is worth taking the added quality without incompatibility issue.
- More importantly, most people might currently use a more recent version of astropy, whereas the likelihood of the use v3.0.4 as requirement in a project is quite low