### PR TITLE
fix: rename misleading function

### DIFF
--- a/hrvanalysis/preprocessing.py
+++ b/hrvanalysis/preprocessing.py
@@ -132,7 +132,7 @@ def remove_ectopic_beats(rr_intervals: List[float], method: str = "malik",
                 previous_outlier = False
                 continue
 
-            if is_valid_rr_interval(rr_interval, rr_intervals[i + 1], method=method,
+            if is_rr_interval_within_bounds(rr_interval, rr_intervals[i + 1], method=method,
                           custom_rule=custom_removing_rule):
                 nn_intervals.append(rr_intervals[i + 1])
             else:
@@ -146,10 +146,10 @@ def remove_ectopic_beats(rr_intervals: List[float], method: str = "malik",
     return nn_intervals
 
 
-def is_valid_rr_interval(rr_interval: int, next_rr_interval: float, method: str = "malik",
+def is_rr_interval_within_bounds(rr_interval: int, next_rr_interval: float, method: str = "malik",
                custom_rule: float = 0.2) -> bool:
     """
-    Test if the rr_interval is valid (not an outlier)
+    Test if the rr_interval is not an outlier according to certain criteria.
 
     Parameters
     ----------

--- a/hrvanalysis/preprocessing.py
+++ b/hrvanalysis/preprocessing.py
@@ -132,7 +132,7 @@ def remove_ectopic_beats(rr_intervals: List[float], method: str = "malik",
                 previous_outlier = False
                 continue
 
-            if is_outlier(rr_interval, rr_intervals[i + 1], method=method,
+            if is_valid_rr_interval(rr_interval, rr_intervals[i + 1], method=method,
                           custom_rule=custom_removing_rule):
                 nn_intervals.append(rr_intervals[i + 1])
             else:
@@ -146,10 +146,10 @@ def remove_ectopic_beats(rr_intervals: List[float], method: str = "malik",
     return nn_intervals
 
 
-def is_outlier(rr_interval: int, next_rr_interval: float, method: str = "malik",
+def is_valid_rr_interval(rr_interval: int, next_rr_interval: float, method: str = "malik",
                custom_rule: float = 0.2) -> bool:
     """
-    Test if the rr_interval is an outlier
+    Test if the rr_interval is valid (not an outlier)
 
     Parameters
     ----------


### PR DESCRIPTION
Fix https://github.com/Aura-healthcare/hrv-analysis/issues/34

**Issue:**
is_outlier was returning True if rr interval was not an outlier according to different methods (MALIK_RULE, KAMATH_RULE ...) and was used with this behavior.

**Fix:**
Rename it is_valid_rr_interval to be more consistent.